### PR TITLE
Add secure secrets to operator and applications. Add EOS Public and SparkPi example for secure secrets. Update README for the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,31 @@
 [![Build Status](https://travis-ci.org/GoogleCloudPlatform/spark-on-k8s-operator.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/spark-on-k8s-operator.svg?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/GoogleCloudPlatform/spark-on-k8s-operator)](https://goreportcard.com/report/github.com/GoogleCloudPlatform/spark-on-k8s-operator)
 
-**This is not an officially supported Google product.**
+**This work is in progress and experimental**
 
-## Project Status
+This repository is an attempt to run cloud-native, on-demand and self-healing Spark on Kubernetes natively on Openstack private cloud.
 
-**Project status:** *alpha* 
+It is based on [GoogleCloudPlatform/spark-on-k8s-operator](hhttps://github.com/GoogleCloudPlatform/spark-on-k8s-operator)
 
-Spark Operator is still under active development and has not been extensively tested in production environment yet. Backward compatibility of the APIs is not guaranteed for alpha releases.
+## Architecture
 
-Customization of Spark pods, e.g., mounting ConfigMaps and PersistentVolumes is currently experimental and implemented using a Kubernetes
-[Initializer](https://kubernetes.io/docs/admin/extensible-admission-controllers/#initializers), which is a Kubernetes **alpha** feature and 
-requires a Kubernetes cluster with alpha features enabled. The Initializer can be disabled if there's no need for pod customization or
- if running on an alpha cluster is not desirable. Check out the [Quick Start Guide](docs/quick-start-guide.md#configuration) on how to disable
- the Initializer.
+* [SparkOperator and sparkctl Design](docs/design.md)
+* [Original project](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator)
 
-## Prerequisites
+## User guide - cluster management and submitting applications
 
-* Version >= 1.8 of Kubernetes.
+* [Openstack Spark cluster management - opsparkctl](opsparkctl/README.md)
+* [Application examples](examples)
+* [Submit Spark jobs - sparkctl](sparkctl/README.md)
 
-Spark Operator relies on [garbage collection](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/) support for 
-custom resources and **optionally** the [Initializers](https://kubernetes.io/docs/admin/extensible-admission-controllers/#initializers) which are in Kubernetes 1.8+.
-
-**Due to this [bug](https://github.com/kubernetes/kubernetes/issues/56018) in Kubernetes 1.9 and earlier, CRD objects with
-escaped quotes (e.g., `spark.ui.port\"`) in map keys can cause serialization problems in the API server. So please pay
-extra attention to make sure no offending escaping is in your `SparkAppliction` CRD objects, particularly if you use 
-Kubernetes prior to 1.10.**   
-
-## Get Started
-
-Get started quickly with the Spark Operator using the [Quick Start Guide](docs/quick-start-guide.md). 
-
-If you are running the Spark Operator on Google Kubernetes Engine and want to use Google Cloud Storage (GCS) and/or BigQuery for reading/writing data, also refer to the [GCP guide](docs/gcp.md).
-
-For more information, check the [Design](docs/design.md), [API Specification](docs/api.md) and detailed [User Guide](docs/user-guide.md).
-
-## Overview
-
-Spark Operator aims to make specifying and running [Spark](https://github.com/apache/spark) 
-applications as easy and idiomatic as running other workloads on Kubernetes. It uses a 
-[CustomResourceDefinition (CRD)](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/) of 
-`SparkApplication` objects for specifying, running, and surfacing status of Spark applications. For a complete reference 
-of the API definition of the `SparkApplication` CRD, please refer to [API Definition](docs/api.md). For details on its design, 
-please refer to the [design doc](docs/design.md). It requires Spark 2.3 and above that supports Kubernetes as a native scheduler 
-backend. Below are some example things that the Spark Operator is able to automate (some are to be implemented):
-* Submitting applications on behalf of users so they don't need to deal with the submission process and the `spark-submit` command.
-* Mounting user-specified ConfigMaps and volumes into the driver and executor Pods.
-* Mounting ConfigMaps carrying Spark or Hadoop configuration files that are to be put into a directory referred to by the 
-environment variable `SPARK_CONF_DIR` or `HADOOP_CONF_DIR` into the driver and executor Pods. Example use cases include 
-shipping a `log4j.properties` file for configuring logging and a `core-site.xml` file for configuring Hadoop and/or HDFS 
-access.
-* Creating a `NodePort` service for the Spark UI running on the driver so the UI can be accessed from outside the Kubernetes 
-cluster, without needing to use API server proxy or port forwarding.
-
-To make such automation possible, Spark Operator uses the `SparkApplication` CRD and a corresponding CRD controller as well as an 
-[initializer](https://kubernetes.io/docs/admin/extensible-admission-controllers/#initializers). The CRD controller setups the 
-environment for an application and submits the application to run on behalf of the user, whereas the initializer handles customization 
-of the Spark Pods. It also supports running Spark applications on standard [cron](https://en.wikipedia.org/wiki/Cron) schedules using 
-the `ScheduledSparkApplication` CRD and the corresponding CRD controller.
-
-## Features
-
-Spark Operator currently supports the following list of features:
-
-* Supports Spark 2.3 and up.
-* Supports automatic application submission on behalf of users for each new `SparkAppliation` object observed.
-* Supports running an application on a standard [cron](https://en.wikipedia.org/wiki/Cron) schedule.
-* Supports automatic application re-submission for updated `SparkAppliation` objects with updated specification.
-* Supports automatic application restart with a configurable restart policy.
-* Supports automatic retries of failed submissions with optional linear back-off.
-* Supports mounting user-specified ConfigMaps and volumes (not supported by Spark itself).
-* Supports mounting local Hadoop configuration as a Kubernetes ConfigMap automatically via `sparkctl`.
-* Supports automatically staging local application dependencies to Google Cloud Storage (GCS) via `sparkctl`.
-
-The following list of features is planned:
-
-* Supports automatically staging local application dependencies to HTTP servers and S3.
-* Supports exporting Kubernetes events to Stackdriver.
-* Supports automatic scale up and down when the number of executor instances changes.
-* Supports automatically copying application logs to a central place, e.g., a GCS bucket, for bookkeeping, post-run checking, and analysis.
-* Supports automatically creating namespaces and setting up RBAC roles and quotas, and running users' applications in separate 
-namespaces for better resource isolation and quota management. 
+## Spark Operator overview
+* [Quick Start Guide - SparkOperator](docs/quick-start-guide.md)
+* [API Specification - SparkOperator](docs/api.md) 
+* [Detailed Guide - SparkOperator ](docs/user-guide.md)
 
 ## Motivations
 
-This approach is completely different than the one that has the submission client creates a CRD object. Having externally 
+This approach is to have the submission client create a CRD object. Having externally 
 created and managed CRD objects offer the following benefits:
 * Things like creating namespaces and setting up RBAC roles and resource quotas represent a separate concern and are better 
 done before applications get submitted.

--- a/examples/events-select.yaml
+++ b/examples/events-select.yaml
@@ -1,0 +1,60 @@
+#
+# Copyright 2017 CERN/Switzerland
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.k8s.io/v1alpha1"
+kind: SparkApplication
+metadata:
+  name: events-select
+  namespace: default
+spec:
+  type: Scala
+  mode: cluster
+  image: "gitlab-registry.cern.ch/db/spark-service/docker-registry/spark-on-k8s-xrootd:v2.3.0-2.7.4-master"
+  imagePullPolicy: Always
+  mainClass: org.sparkservice.sparkrootapplications.examples.EventsSelect
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-service-examples_2.11-0.0.1.jar"
+  arguments:
+    - "root://eospublic.cern.ch://eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/0000/FEF1B99B-BF77-E011-B0A0-E41F1318174C.root"
+  sparkConf:
+    "spark.kubernetes.authenticate.submission.caCertFile": /spark-secrets/client-ca
+    "spark.kubernetes.authenticate.submission.clientKeyFile": /spark-secrets/client-key
+    "spark.kubernetes.authenticate.submission.clientCertFile": /spark-secrets/client-cert
+    "spark.kubernetes.authenticate.driver.caCertFile": /spark-secrets/client-ca
+    "spark.kubernetes.authenticate.driver.clientKeyFile": /spark-secrets/client-key
+    "spark.kubernetes.authenticate.driver.clientCertFile": /spark-secrets/client-cert
+  deps:
+    jars:
+      - http://central.maven.org/maven2/org/diana-hep/root4j/0.1.6/root4j-0.1.6.jar
+      - http://central.maven.org/maven2/org/apache/bcel/bcel/5.2/bcel-5.2.jar
+      - http://central.maven.org/maven2/org/diana-hep/spark-root_2.11/0.1.16/spark-root_2.11-0.1.16.jar
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "1024m"
+    labels:
+      version: 2.3.0
+    serviceAccount: spark
+    secrets:
+      - name: spark-secrets
+        path: /spark-secrets
+        secretType: Opaque
+  executor:
+    instances: 1
+    cores: 2
+    memory: "2048m"
+    labels:
+      version: 2.3.0
+  restartPolicy: Never

--- a/examples/spark-secrets-pi.yaml
+++ b/examples/spark-secrets-pi.yaml
@@ -1,0 +1,53 @@
+#
+# Copyright 2017 CERN/Switzerland
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.k8s.io/v1alpha1"
+kind: SparkApplication
+metadata:
+  name: spark-pi
+  namespace: default
+spec:
+  type: Scala
+  mode: cluster
+  image: "gitlab-registry.cern.ch/db/spark-service/docker-registry/spark-on-k8s-xrootd:v2.3.0-2.7.4-master"
+  imagePullPolicy: Always
+  mainClass: org.sparkservice.sparkrootapplications.examples.SparkPi
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-service-examples_2.11-0.0.1.jar"
+  sparkConf:
+    "spark.kubernetes.authenticate.submission.caCertFile": /spark-secrets/client-ca
+    "spark.kubernetes.authenticate.submission.clientKeyFile": /spark-secrets/client-key
+    "spark.kubernetes.authenticate.submission.clientCertFile": /spark-secrets/client-cert
+    "spark.kubernetes.authenticate.driver.caCertFile": /spark-secrets/client-ca
+    "spark.kubernetes.authenticate.driver.clientKeyFile": /spark-secrets/client-key
+    "spark.kubernetes.authenticate.driver.clientCertFile": /spark-secrets/client-cert
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "1024m"
+    labels:
+      version: 2.3.0
+    serviceAccount: spark
+    secrets:
+      - name: spark-secrets
+        path: /spark-secrets
+        secretType: Opaque
+  executor:
+    instances: 1
+    cores: 2
+    memory: "2048m"
+    labels:
+      version: 2.3.0
+  restartPolicy: Never

--- a/manifest/spark-operator-with-secrets.yaml
+++ b/manifest/spark-operator-with-secrets.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Google LLC
+# Copyright 2017 CERN/Switzerland
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,11 +39,20 @@ spec:
         pending: []  
     spec:
       serviceAccountName: sparkoperator
+      volumes:
+        - name: client-certs
+          secret:
+            secretName: spark-secrets
       containers:
       - name: sparkoperator
-        image: gcr.io/spark-operator/spark-operator:v2.3.0-v1alpha1-latest
+        image: gitlab-registry.cern.ch/db/spark-service/docker-registry/spark-on-k8s-operator:v1alpha1
         imagePullPolicy: Always
         command: ["/usr/bin/spark-operator"]
         args:
         - -logtostderr
         - -enable-initializer=false
+        volumeMounts:
+          - name: client-certs
+            # Application additionally requires to include 3 spark.kubernetes.authenticate.submission.<auth-files>
+            # if you don't need it, remove
+            mountPath: '/spark-secrets'

--- a/manifest/spark-secrets.yaml
+++ b/manifest/spark-secrets.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: spark-secrets
+  # namespace: not defined, since it needs to be in each namespace
+data:
+  # Populate the following files with etcd TLS configuration if desired, but leave blank if
+  # not using TLS for etcd.
+  # This self-hosted install expects three files with the following names.  The values
+  # should be base64 encoded strings of the entire contents of each file.
+  client-key: {key}
+  client-cert: {cert}
+  client-ca: {ca}

--- a/opsparkctl/README.md
+++ b/opsparkctl/README.md
@@ -1,0 +1,7 @@
+# CERN Spark Service - Spark on Kubernetes and Openstack
+
+**This work is in progress and experimental**
+
+Command line tool `opsparkctl` holds all tools for creating/deleting/resizing/reinitializing spark-on-k8s cluster on Openstack, based on `spark-on-k8s-operator`. 
+
+Idea is to provide users and admins an architecture, in which user in general should be able to fetch configuration of the cluster he is allowed to use, and be able to seemlessly submit Spark jobs using `sparkctl`.


### PR DESCRIPTION
Please review README and examples https://github.com/cerndb/spark-on-k8s-operator/blob/62c02fd678ec56e1f49329ef251cd0eebc686b98/README.md

@LucaCanali @mevangem 